### PR TITLE
Update jsDelivr links

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Standalone build of Monkberry for use in browsers.
 ## CDN
 
 ```
-https://cdn.jsdelivr.net/monkberry-standalone/latest/monkberry.min.js
+https://cdn.jsdelivr.net/npm/monkberry-standalone@latest/monkberry.min.js
 ```
 [other versions on jsDelivr](https://www.jsdelivr.com/projects/monkberry-standalone)
 
@@ -13,7 +13,7 @@ https://cdn.jsdelivr.net/monkberry-standalone/latest/monkberry.min.js
 Include it to your page.
 
 ```html
-<script src="https://cdn.jsdelivr.net/monkberry-standalone/latest/monkberry.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/monkberry-standalone@latest/monkberry.min.js"></script>
 ```
 
 Define template with `text/monkberry`.


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the links now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/npm/monkberry-standalone.

Feel free to ping me if you have any questions regarding this change.